### PR TITLE
Added a catch-all Exception handler

### DIFF
--- a/censys_subdomain_finder.py
+++ b/censys_subdomain_finder.py
@@ -27,6 +27,10 @@ def find_subdomains(domain, api_id, api_secret):
     except censys.base.CensysRateLimitExceededException:
         sys.stderr.write('[-] Looks like you exceeded your Censys account limits rate. Exiting\n')
         exit(1)
+    except censys.base.CensysException as e:
+        # catch the Censys Base exception, example "only 1000 first results are available"
+        sys.stderr.write('[-] Something bad happened, ' + repr(e))
+        return set(subdomains)
 
 # Filters out uninteresting subdomains
 def filter_subdomains(domain, subdomains):


### PR DESCRIPTION
Sometimes the censys module throwns an Exception that is not catched by the censys_subdomain_finder.
It is annoying, because most of times the reason is: cannot retrieve more than 1000 results, meaning, we
have already found 1000 subdomains !!! but our application crashes. I fixed that catching the base exception.