### PR TITLE
Fix not exit

### DIFF
--- a/censys_subdomain_finder.py
+++ b/censys_subdomain_finder.py
@@ -27,6 +27,10 @@ def find_subdomains(domain, api_id, api_secret):
     except censys.base.CensysRateLimitExceededException:
         sys.stderr.write('[-] Looks like you exceeded your Censys account limits rate. Exiting\n')
         exit(1)
+    except censys.base.CensysException as e:
+        # catch the Censys Base exception, example "only 1000 first results are available"
+        sys.stderr.write('[-] Something bad happened, ' + repr(e))
+        return set(subdomains)
 
 # Filters out uninteresting subdomains
 def filter_subdomains(domain, subdomains):

--- a/censys_subdomain_finder.py
+++ b/censys_subdomain_finder.py
@@ -26,7 +26,7 @@ def find_subdomains(domain, api_id, api_secret):
         exit(1)
     except censys.base.CensysRateLimitExceededException:
         sys.stderr.write('[-] Looks like you exceeded your Censys account limits rate. Exiting\n')
-        exit(1)
+        return set(subdomains)
     except censys.base.CensysException as e:
         # catch the Censys Base exception, example "only 1000 first results are available"
         sys.stderr.write('[-] Something bad happened, ' + repr(e))


### PR DESCRIPTION
I made two fixes.
1. Do not exit the application just because something went wrong, if CensysRateLimitExceededException is thrown, we may have already found many subdomains, return them instead of exit(1)
2. Catch-all exception handler, this is useful because, the script actully crashes because it only catches two exception types. When, for example, the script tries to fetch more than 1000 results, censys will throw an exception crashing the app and loosing all 1000 subdomains we already found... Catching the base exception is useful for the future if censys module has introduced new Exception classes.