### PR TITLE
Fix syntax warning over comparison of literals using is.

### DIFF
--- a/censys_subdomain_finder.py
+++ b/censys_subdomain_finder.py
@@ -38,7 +38,7 @@ def filter_subdomains(domain, subdomains):
 
 # Prints the list of found subdomains to stdout
 def print_subdomains(domain, subdomains, time_ellapsed):
-    if len(subdomains) is 0:
+    if len(subdomains) == 0:
         print('[-] Did not find any subdomain')
         return
 
@@ -50,7 +50,7 @@ def print_subdomains(domain, subdomains, time_ellapsed):
 
 # Saves the list of found subdomains to an output file
 def save_subdomains_to_file(subdomains, output_file):
-    if output_file is None or len(subdomains) is 0:
+    if output_file is None or len(subdomains) == 0:
         return
 
     try:


### PR DESCRIPTION
Fixes some of the warnings reported in #10 .

```
 find . -iname '*.py' | xargs -P4 -I{} python3.8 -Wall -m py_compile {}     
./censys_subdomain_finder.py:41: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if len(subdomains) is 0:
./censys_subdomain_finder.py:53: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if output_file is None or len(subdomains) is 0:
```