### PR TITLE
Censys v2 API + non-commercial mode support

### DIFF
--- a/censys_subdomain_finder.py
+++ b/censys_subdomain_finder.py
@@ -7,13 +7,15 @@ import cli
 import os
 import time
 
+NON_COMMERCIAL_API_LIMIT = 1000
+
 # Finds subdomains of a domain using Censys API
 def find_subdomains(domain, api_id, api_secret, limit_results):
     try:
         censys_certificates = CensysCertificates(api_id=api_id, api_secret=api_secret)
         certificate_query = 'parsed.names: %s' % domain
         if limit_results:
-            certificates_search_results = censys_certificates.search(certificate_query, fields=['parsed.names'], max_records=1000)
+            certificates_search_results = censys_certificates.search(certificate_query, fields=['parsed.names'], max_records=NON_COMMERCIAL_API_LIMIT)
         else:
             certificates_search_results = censys_certificates.search(certificate_query, fields=['parsed.names'])
 
@@ -90,7 +92,7 @@ if __name__ == "__main__":
 
     limit_results = args.non_commercial
     if limit_results:
-        print('[*] Applying non-commerical limits (1000 results at most)')
+        print('[*] Applying non-commerical limits (' + NON_COMMERCIAL_API_LIMIT + ' results at most)')
 
     if None in [ censys_api_id, censys_api_secret ]:
         sys.stderr.write('[!] Please set your Censys API ID and secret from your environment (CENSYS_API_ID and CENSYS_API_SECRET) or from the command line.\n')

--- a/censys_subdomain_finder.py
+++ b/censys_subdomain_finder.py
@@ -8,12 +8,15 @@ import os
 import time
 
 # Finds subdomains of a domain using Censys API
-def find_subdomains(domain, api_id, api_secret):
+def find_subdomains(domain, api_id, api_secret, limit_results):
     try:
         censys_certificates = CensysCertificates(api_id=api_id, api_secret=api_secret)
         certificate_query = 'parsed.names: %s' % domain
-        certificates_search_results = censys_certificates.search(certificate_query, fields=['parsed.names'])
-        
+        if limit_results:
+            certificates_search_results = censys_certificates.search(certificate_query, fields=['parsed.names'], max_records=1000)
+        else:
+            certificates_search_results = censys_certificates.search(certificate_query, fields=['parsed.names'])
+
         # Flatten the result, and remove duplicates
         subdomains = []
         for search_result in certificates_search_results:
@@ -61,10 +64,10 @@ def save_subdomains_to_file(subdomains, output_file):
     except IOError as e:
         sys.stderr.write('[-] Unable to write to output file %s : %s\n' % (output_file, e))
 
-def main(domain, output_file, censys_api_id, censys_api_secret):
+def main(domain, output_file, censys_api_id, censys_api_secret, limit_results):
     print('[*] Searching Censys for subdomains of %s' % domain)
     start_time = time.time()
-    subdomains = find_subdomains(domain, censys_api_id, censys_api_secret)
+    subdomains = find_subdomains(domain, censys_api_id, censys_api_secret, limit_results)
     subdomains = filter_subdomains(domain, subdomains)
     end_time = time.time()
     time_ellapsed = round(end_time - start_time, 1)
@@ -85,8 +88,12 @@ if __name__ == "__main__":
         censys_api_id = args.censys_api_id
         censys_api_secret = args.censys_api_secret
 
+    limit_results = args.non_commercial
+    if limit_results:
+        print('[*] Applying non-commerical limits (1000 results at most)')
+
     if None in [ censys_api_id, censys_api_secret ]:
         sys.stderr.write('[!] Please set your Censys API ID and secret from your environment (CENSYS_API_ID and CENSYS_API_SECRET) or from the command line.\n')
         exit(1)
 		
-    main(args.domain, args.output_file, censys_api_id, censys_api_secret)
+    main(args.domain, args.output_file, censys_api_id, censys_api_secret, limit_results)

--- a/censys_subdomain_finder.py
+++ b/censys_subdomain_finder.py
@@ -37,7 +37,7 @@ def filter_subdomains(domain, subdomains):
 
 # Prints the list of found subdomains to stdout
 def print_subdomains(domain, subdomains, time_ellapsed):
-    if len(subdomains) is 0:
+    if len(subdomains) == 0:
         print('[-] Did not find any subdomain')
         return
 
@@ -49,7 +49,7 @@ def print_subdomains(domain, subdomains, time_ellapsed):
 
 # Saves the list of found subdomains to an output file
 def save_subdomains_to_file(subdomains, output_file):
-    if output_file is None or len(subdomains) is 0:
+    if output_file is None or len(subdomains) == 0:
         return
 
     try:

--- a/censys_subdomain_finder.py
+++ b/censys_subdomain_finder.py
@@ -90,9 +90,9 @@ if __name__ == "__main__":
         censys_api_id = args.censys_api_id
         censys_api_secret = args.censys_api_secret
 
-    limit_results = args.non_commercial
+    limit_results = not args.commercial
     if limit_results:
-        print('[*] Applying non-commerical limits (' + NON_COMMERCIAL_API_LIMIT + ' results at most)')
+        print('[*] Applying non-commerical limits (' + str(NON_COMMERCIAL_API_LIMIT) + ' results at most)')
 
     if None in [ censys_api_id, censys_api_secret ]:
         sys.stderr.write('[!] Please set your Censys API ID and secret from your environment (CENSYS_API_ID and CENSYS_API_SECRET) or from the command line.\n')

--- a/censys_subdomain_finder.py
+++ b/censys_subdomain_finder.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-import censys.certificates
-import censys.ipv4
+from censys.search import CensysCertificates
 import censys
 import sys
 import cli
@@ -11,7 +10,7 @@ import time
 # Finds subdomains of a domain using Censys API
 def find_subdomains(domain, api_id, api_secret):
     try:
-        censys_certificates = censys.certificates.CensysCertificates(api_id=api_id, api_secret=api_secret)
+        censys_certificates = CensysCertificates(api_id=api_id, api_secret=api_secret)
         certificate_query = 'parsed.names: %s' % domain
         certificates_search_results = censys_certificates.search(certificate_query, fields=['parsed.names'])
         
@@ -21,13 +20,13 @@ def find_subdomains(domain, api_id, api_secret):
             subdomains.extend(search_result['parsed.names'])
 		
         return set(subdomains)
-    except censys.base.CensysUnauthorizedException:
+    except censys.common.exceptions.CensysUnauthorizedException:
         sys.stderr.write('[-] Your Censys credentials look invalid.\n')
         exit(1)
-    except censys.base.CensysRateLimitExceededException:
+    except censys.common.exceptions.CensysRateLimitExceededException:
         sys.stderr.write('[-] Looks like you exceeded your Censys account limits rate. Exiting\n')
         return set(subdomains)
-    except censys.base.CensysException as e:
+    except censys.common.exceptions.CensysException as e:
         # catch the Censys Base exception, example "only 1000 first results are available"
         sys.stderr.write('[-] Something bad happened, ' + repr(e))
         return set(subdomains)

--- a/cli.py
+++ b/cli.py
@@ -26,9 +26,9 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    '--non-commercial',
-    help = 'For Censys non-commercial account, results should be limited',
-    dest = 'non_commercial',
+    '--commercial',
+    help = 'Don\'t limit search results (for commercial accounts)',
+    dest = 'commercial',
     action='store_true',
     default=False
 )

--- a/cli.py
+++ b/cli.py
@@ -24,3 +24,11 @@ parser.add_argument(
     help = 'Censys API secret. Can also be defined using the CENSYS_API_SECRET environment variable',
     dest = 'censys_api_secret'
 )
+
+parser.add_argument(
+    '--non-commercial',
+    help = 'For Censys non-commercial account, results should be limited',
+    dest = 'non_commercial',
+    action='store_true',
+    default=False
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-censys==2.0.0; python_version > '3.6'
-censys==0.0.8; python_version <= '3.6'
+censys==2.1.2


### PR DESCRIPTION
# Censys v1 API is deprecated since 11/30/2021 and so is CloudFlair

https://support.censys.io/hc/en-us/articles/4404436837652-Search-1-0-and-IPv4-Banners-Deprecated-Resources-and-Available-Alternatives
https://support.censys.io/hc/en-us/articles/360059306252-Censys-Search-2-0-Release-Timeline-FAQ-
Migrated to Censys Search 2.0.

# Added support for non-commercial accounts - limited results.